### PR TITLE
Set custom component default value

### DIFF
--- a/src/components/QueryBuilderRule.vue
+++ b/src/components/QueryBuilderRule.vue
@@ -39,7 +39,7 @@ export default {
     }
   },
 
-  beforeMount: function beforeMount() {
+  beforeMount () {
     if (this.rule.type === 'custom-component') {
       this.$options.components[this.id] = this.rule.component;
       if(this.query.value === null)

--- a/src/components/QueryBuilderRule.vue
+++ b/src/components/QueryBuilderRule.vue
@@ -39,9 +39,20 @@ export default {
     }
   },
 
-  beforeMount () {
+  beforeMount: function beforeMount() {
     if (this.rule.type === 'custom-component') {
       this.$options.components[this.id] = this.rule.component;
+      if(this.query.value === null)
+      {
+        if(typeof this.rule.default !== 'undefined')
+        {
+          this.query.value = deepClone(this.rule.default);
+        }
+        else
+        {
+          this.query.value = {};
+        }
+      }
     }
   },
 


### PR DESCRIPTION
Fix for custom components not having an initial value before the component is mounted. Fixes the situation where using e.g. `value.something` in the custom component's field's v-model results in "Cannot read property 'something' of undefined".